### PR TITLE
Update for monitoring issue for y-axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## 2025-04-10
+
+### Fixed
+
+- Removed passing major_locator to axis (this overwrites the defined labels)
+- Passes tick values that correspond with tick labels and label range to axis  
+- Commented out the redefining of ticks in axis  

--- a/gmaopy/stats/statdimensions.py
+++ b/gmaopy/stats/statdimensions.py
@@ -65,6 +65,7 @@ class LevelPlotDimension(Dimension):
     def process_axis(self,layout,subplot,axis,values,curves):
 
         axis_values = self.process_values(values,curves)
+        
         major_locator = None
         if len(values) > 100:
             div = 20
@@ -80,7 +81,8 @@ class LevelPlotDimension(Dimension):
                 if (values[i] % div) == 0 or i == 0:
                     vals.append(values[i])
             values = vals
-            major_locator = IndexLocator(div,0)
+            axis_values = vals
+            #major_locator = IndexLocator(div,0.5) # SJR 20250410 see commit 
         labels = self.labels_for_float(values)
         '''
         if 'absolute_max' in axis:

--- a/semperpy/plot/mplib/axis.py
+++ b/semperpy/plot/mplib/axis.py
@@ -66,7 +66,7 @@ class Axis(Attribute):
             if labels is not None:
                 if ticks is None:
                     ticks = list(range(len(labels)))
-                ticks = list(range(len(labels)))
+                #ticks = list(range(len(labels))) # SJR 20250410 see commit
                 subplot.set_yticks(ticks)
                 subplot.set_yticklabels(labels)
             if date:


### PR DESCRIPTION
Fixing bug that causes lack of y-labels on plots with >30 y values. 
Update removes the use of major_locator when ticks and labels are already defined.