### PR TITLE
Patch to fix plotting for SMAP observation statistics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+Some checks were added to semperpy/plot/mplib/layout.py to trap list objects where scalar objects were expected. This is likely the result of misinterpretation of matplotlib return values that are tuples or have become tuples. For example: val = plt.plot(a,b) should perhaps be val, = plt.plot(a,b). Other similar patches have been noted in the codes implemented by other developers. A better fix would be to correct the origin of the misassigned tuple values.
 
 ### Removed
 

--- a/semperpy/plot/mplib/layout.py
+++ b/semperpy/plot/mplib/layout.py
@@ -169,6 +169,14 @@ class Layout(object):
         if 'alpha' in kargs:
             alpha = kargs['alpha']
             del(kargs['alpha'])
+
+        newlines = []
+        for line in lines:
+            if isinstance(line, list):
+                newlines.append(line[0])
+            else:
+                newlines.append(line)
+        lines = newlines
         legend = subplot.legend(lines,texts,**kargs)
         # make legend transparent
         legend.get_frame().set_alpha(alpha)
@@ -450,6 +458,8 @@ class PlaceLegend(Spacer):
             subplot.set_position([bbox.x0 + height/2,bbox.y0,bbox.width,bbox.height-height/2])
             #legend.set_bbox_to_anchor((0.5,-height-vertical_offset ))
         elif position == 'topleft':
+            if isinstance(vertical_offset, list):
+                vertical_offset = vertical_offset[0]
             subplot.set_position([bbox.x0,bbox.y0,bbox.width,bbox.height-vertical_offset])
             #legend.set_bbox_to_anchor((bbox.x0,1 + height + vertical_offset ))
         elif position == 'bottomleft':


### PR DESCRIPTION
This PR applies patches to fix a recurring issue that may result from improper interpretation of Matplotlib return values that are tuples or have become tuples. For example: val = plt.plot(a,b) should be val, = plt.plot(a,b). This has not been confirmed however. The solution for now is to check for list objects where scalars were expected and return the first item in the list as the expected value.